### PR TITLE
Cleaner `Cmd.Result` constructor (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A library that helps your app interact with shells on Android.
 ## Quickstart
 Include the library in your modules `build.gradle` file:
 ```groovy
-implementation 'eu.darken.rxshell:core:0.9.1'
+implementation 'eu.darken.rxshell:core:0.9.2'
 ```
 
 Now your project is ready to use the library, let's quickly talk about a few core concepts:

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.android.library'
 
 def versionMajor = 0
 def versionMinor = 9
-def versionPatch = 1
+def versionPatch = 2
 def myVersionCode = versionMajor * 10000 + versionMinor * 100 + versionPatch
 def myVersionName = "${versionMajor}.${versionMinor}.${versionPatch}"
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.android.library'
 
 def versionMajor = 0
 def versionMinor = 9
-def versionPatch = 2
+def versionPatch = 3
 def myVersionCode = versionMajor * 10000 + versionMinor * 100 + versionPatch
 def myVersionName = "${versionMajor}.${versionMinor}.${versionPatch}"
 

--- a/core/src/main/java/eu/darken/rxshell/cmd/Cmd.java
+++ b/core/src/main/java/eu/darken/rxshell/cmd/Cmd.java
@@ -86,7 +86,7 @@ public class Cmd {
         }
 
         public Result(Cmd cmd, int exitCode) {
-            this(cmd, exitCode, null, null);
+            this(cmd, exitCode, new ArrayList<>(), new ArrayList<>());
         }
 
         public Result(Cmd cmd, int exitCode, @Nullable List<String> output, @Nullable List<String> errors) {

--- a/core/src/main/java/eu/darken/rxshell/cmd/Cmd.java
+++ b/core/src/main/java/eu/darken/rxshell/cmd/Cmd.java
@@ -78,8 +78,8 @@ public class Cmd {
     public static class Result {
         private final Cmd cmd;
         private final int exitCode;
-        @Nullable private final List<String> output;
-        @Nullable private final List<String> errors;
+        private final List<String> output;
+        private final List<String> errors;
 
         public Result(Cmd cmd) {
             this(cmd, Cmd.ExitCode.INITIAL);
@@ -118,9 +118,8 @@ public class Cmd {
         /**
          * Your command's output.
          * <p>The shell processes' {@code STDOUT} during the execution your commands.
-         * <p>Maybe null depending on {@link Builder#outputBuffer(boolean)}
+         * <p>Maybe {@code null} depending on {@link Builder#outputBuffer(boolean)}
          */
-        @Nullable
         public List<String> getOutput() {
             return output;
         }
@@ -128,9 +127,8 @@ public class Cmd {
         /**
          * Your command's errors.
          * <p>The shell processes' {@code STDERR} during the execution your commands.
-         * <p>Maybe null depending on {@link Builder#errorBuffer(boolean)} (boolean)}
+         * <p>Maybe {@code null} depending on {@link Builder#errorBuffer(boolean)} (boolean)}
          */
-        @Nullable
         public List<String> getErrors() {
             return errors;
         }

--- a/core/src/test/java/eu/darken/rxshell/cmd/CmdResultTest.java
+++ b/core/src/test/java/eu/darken/rxshell/cmd/CmdResultTest.java
@@ -24,8 +24,8 @@ public class CmdResultTest extends BaseTest {
         Cmd.Result result = new Cmd.Result(cmd);
         assertThat(result.getExitCode(), is(Cmd.ExitCode.INITIAL));
         assertThat(result.getCmd(), is(cmd));
-        assertThat(result.getOutput(), is(nullValue()));
-        assertThat(result.getErrors(), is(nullValue()));
+        assertThat(result.getOutput(), is(not(nullValue())));
+        assertThat(result.getErrors(), is(not(nullValue())));
     }
 
     @Test
@@ -33,8 +33,8 @@ public class CmdResultTest extends BaseTest {
         Cmd.Result result = new Cmd.Result(cmd, Cmd.ExitCode.SHELL_DIED);
         assertThat(result.getExitCode(), is(Cmd.ExitCode.SHELL_DIED));
         assertThat(result.getCmd(), is(cmd));
-        assertThat(result.getOutput(), is(nullValue()));
-        assertThat(result.getErrors(), is(nullValue()));
+        assertThat(result.getOutput(), is(not(nullValue())));
+        assertThat(result.getErrors(), is(not(nullValue())));
     }
 
     @Test


### PR DESCRIPTION
* Upped version to v0.9.2

* As we default to buffers=true, the shorthand constructor should supply empty buffers too.

* Fixed forgotten unit test.