### PR TITLE
Improve error behavior

### DIFF
--- a/core/src/main/java/eu/darken/rxshell/cmd/Cmd.java
+++ b/core/src/main/java/eu/darken/rxshell/cmd/Cmd.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -302,7 +303,9 @@ public class Cmd {
          * Convenience method for {@link #submit(RxCmdShell)} using {@link Single#blockingGet()}
          */
         public Result execute(RxCmdShell shell) {
-            return submit(shell).blockingGet();
+            return submit(shell)
+                    .onErrorReturn(err -> new Result(build(), ExitCode.EXCEPTION, null, Collections.singletonList(err.toString())))
+                    .blockingGet();
         }
     }
 

--- a/core/src/main/java/eu/darken/rxshell/cmd/Cmd.java
+++ b/core/src/main/java/eu/darken/rxshell/cmd/Cmd.java
@@ -301,6 +301,7 @@ public class Cmd {
 
         /**
          * Convenience method for {@link #submit(RxCmdShell)} using {@link Single#blockingGet()}
+         * <br>If a shell can't be opened {@link ExitCode#EXCEPTION} will be returned and an error message.
          */
         public Result execute(RxCmdShell shell) {
             return submit(shell)

--- a/core/src/test/java/eu/darken/rxshell/cmd/CmdBuilderTest.java
+++ b/core/src/test/java/eu/darken/rxshell/cmd/CmdBuilderTest.java
@@ -150,12 +150,15 @@ public class CmdBuilderTest extends BaseTest {
         verify(session).close();
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testExecute_oneshot_exception() throws IOException {
         RxCmdShell shell = mock(RxCmdShell.class);
-        when(shell.open()).thenReturn(Single.error(new IOException()));
+        Exception ex = new IOException("Error message");
+        when(shell.open()).thenReturn(Single.error(ex));
         when(shell.isAlive()).thenReturn(Single.just(false));
 
-        Cmd.builder("").execute(shell);
+        final Cmd.Result result = Cmd.builder("").execute(shell);
+        assertThat(result.getExitCode(), is(Cmd.ExitCode.EXCEPTION));
+        assertThat(result.getErrors(), contains(ex.toString()));
     }
 }


### PR DESCRIPTION
Using the helper function `Cmd.Builder.execute(Shell)` can throw a `RuntimeException` if the shell fails to open, e.g. when trying to open a root shell without `su` existing:

```
Caused by: java.io.IOException: error=13, Permission denied
     at java.lang.UNIXProcess.forkAndExec(Native Method)
     at java.lang.UNIXProcess.<init>(UNIXProcess.java:133)
     at java.lang.ProcessImpl.start(ProcessImpl.java:128)
     at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
     at eu.darken.rxshell.process.DefaultProcessFactory.start(DefaultProcessFactory.java:9) 
     at eu.darken.rxshell.process.RxProcess.lambda$new$1$RxProcess(RxProcess.java:35) 
     at eu.darken.rxshell.process.RxProcess$$Lambda$0.subscribe(Unknown Source:6) 
     at io.reactivex.internal.operators.observable.ObservableCreate.subscribeActual(ObservableCreate.java:40) 
     at io.reactivex.Observable.subscribe(Observable.java:10955) 
     at io.reactivex.internal.operators.observable.ObservableDoFinally.subscribeActual(ObservableDoFinally.java:45) 
     at io.reactivex.Observable.subscribe(Observable.java:10955) 
     at eu.darken.rxshell.process.RxProcess$1.subscribe(RxProcess.java:60) 
     at io.reactivex.internal.operators.single.SingleCreate.subscribeActual(SingleCreate.java:39) 
     at io.reactivex.Single.subscribe(Single.java:2779) 
     at io.reactivex.internal.operators.single.SingleSubscribeOn$SubscribeOnObserver.run(SingleSubscribeOn.java:89) 
     at io.reactivex.Scheduler$DisposeTask.run(Scheduler.java:452) 
     at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:61) 
     at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:52) 
     at java.util.concurrent.FutureTask.run(FutureTask.java:266) 
     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:301) 
     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162) 
     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636) 
     at java.lang.Thread.run(Thread.java:764) 
```

The runtime exception is unexpected and contrasts the other methods which are either `Single`'s and thus have onError options, or are blocking but return a `Cmd.Result` with an error code.

It's easier for developers to deal with this if this method also just returns a `Cmd.Result` with an error code.