### PR TITLE
Addition of `blockingOpen` 

### DIFF
--- a/core/src/main/java/eu/darken/rxshell/cmd/RxCmdShell.java
+++ b/core/src/main/java/eu/darken/rxshell/cmd/RxCmdShell.java
@@ -300,6 +300,25 @@ public class RxCmdShell {
         public Single<Session> open() {
             return build().open();
         }
+
+        /**
+         * Convenience method for {@link #open()} that throws a checked Exception.
+         * <p>E.g.
+         * <br>When you try to open a root shell, but the user denies it, you get an {@link IOException},
+         * <br>instead of a wrapped {@link RuntimeException} when using {@link #open()} with {@link Single#blockingGet()}
+         *
+         * @return an open {@link Session}
+         * @throws IOException if the shell process, e.g. `su` or `sh` can't be opened.
+         */
+        public Session blockingOpen() throws IOException {
+            try {
+                return open().blockingGet();
+            } catch (RuntimeException e) {
+                if (e.getCause() instanceof IOException) {
+                    throw (IOException) e.getCause();
+                } else throw e;
+            }
+        }
     }
 
 }

--- a/core/src/test/java/eu/darken/rxshell/cmd/RxCmdShellBuilderTest.java
+++ b/core/src/test/java/eu/darken/rxshell/cmd/RxCmdShellBuilderTest.java
@@ -6,17 +6,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.IOException;
 import java.util.Collections;
 
 import eu.darken.rxshell.extra.HasEnvironmentVariables;
+import eu.darken.rxshell.shell.RxShell;
 import testtools.BaseTest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RxCmdShellBuilderTest extends BaseTest {
@@ -62,4 +67,25 @@ public class RxCmdShellBuilderTest extends BaseTest {
         verify(m).getEnvironmentVariables(true);
     }
 
+    @Test(expected = IOException.class)
+    public void testBlockingOpen_unwrap() throws IOException {
+        final RxCmdShell.Builder shellBuilder = spy(RxCmdShell.builder());
+
+        RxShell rxShell = mock(RxShell.class);
+        doThrow(new RuntimeException(new IOException())).when(rxShell).open();
+        when(shellBuilder.getRxShell()).thenReturn(rxShell);
+
+        shellBuilder.blockingOpen();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testBlockingOpen() throws IOException {
+        final RxCmdShell.Builder shellBuilder = spy(RxCmdShell.builder());
+
+        RxShell rxShell = mock(RxShell.class);
+        doThrow(new RuntimeException(new ArithmeticException())).when(rxShell).open();
+        when(shellBuilder.getRxShell()).thenReturn(rxShell);
+
+        shellBuilder.blockingOpen();
+    }
 }


### PR DESCRIPTION
Which unwraps IOExceptions from RuntimeException when opening a shell fails.

This makes for nicer coder when not using RxJava 